### PR TITLE
Close: #26

### DIFF
--- a/src/__snapshots__/migration.test.ts.snap
+++ b/src/__snapshots__/migration.test.ts.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SynorMigration getMigrationInfoParser returned function works (for valid filename) 1`] = `
-Object {
-  "filename": "001.do--Test.sql",
-  "title": "Test",
-  "type": "do",
-  "version": "001",
-}
-`;
-
 exports[`SynorMigration returns data 1`] = `
 Object {
   "body": "SELECT 1;",

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,10 @@ export type SynorConfig = {
      * Separator between `Version.Type` and `Title.Extension` of the migration filename
      */
     separator: string
+    /**
+     * Regular expression pattern for filename extension
+     */
+    extension: string
   }
   migrationInfoParser: MigrationInfoParser
   getAdvisoryLockId: GetAdvisoryLockId
@@ -75,7 +79,8 @@ const defaultConfig: Partial<SynorConfig> = {
   migrationInfoNotation: {
     do: 'do',
     undo: 'undo',
-    separator: '.'
+    separator: '.',
+    extension: '.+'
   },
   getAdvisoryLockId,
   getUserInfo: getGitUserInfo

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -1,4 +1,4 @@
-import { SynorMigration, getMigrationInfoParser } from './migration'
+import { getMigrationInfoParser, SynorMigration } from './migration'
 
 describe('SynorMigration', () => {
   test('returns data', () => {
@@ -17,7 +17,8 @@ describe('SynorMigration', () => {
       migrationInfoParser = getMigrationInfoParser({
         do: 'do',
         undo: 'undo',
-        separator: '--'
+        separator: '--',
+        extension: 'js|sql'
       })
     })
 
@@ -26,7 +27,29 @@ describe('SynorMigration', () => {
     })
 
     test('returned function works (for valid filename)', () => {
-      expect(migrationInfoParser('001.do--Test.sql')).toMatchSnapshot()
+      expect(migrationInfoParser('001.do--Test.sql')).toMatchInlineSnapshot(`
+        Object {
+          "filename": "001.do--Test.sql",
+          "title": "Test",
+          "type": "do",
+          "version": "001",
+        }
+      `)
+
+      expect(migrationInfoParser('001.do--Test.js')).toMatchInlineSnapshot(`
+        Object {
+          "filename": "001.do--Test.js",
+          "title": "Test",
+          "type": "do",
+          "version": "001",
+        }
+      `)
+
+      expect(() =>
+        migrationInfoParser('001.do--Test.json')
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid Filename: 001.do--Test.json"`
+      )
     })
 
     test('returned function throws (for invalid filename)', () => {

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -46,13 +46,16 @@ export type MigrationHistory = Array<
 function getMigrationInfoRegex({
   do: DO,
   undo: UNDO,
-  separator: SEPARATOR
+  separator: SEPARATOR,
+  extension: EXTENSION
 }: SynorConfig['migrationInfoNotation']): RegExp {
   const version = `[0-9]+`
   const type = [DO, UNDO].join('|')
   const title = '[\\S ]+'
 
-  return new RegExp(`^(${version}).(${type})${SEPARATOR}(${title})\\.(.+)$`)
+  return new RegExp(
+    `^(${version}).(${type})${SEPARATOR}(${title})\\.(${EXTENSION})$`
+  )
 }
 
 export const getMigrationInfoParser = (


### PR DESCRIPTION
Support `migrationInfoNotation.extension` in `SynorConfig`:

```js
Synor({
  migrationInfoNotation: {
    extension: 'sql|js'
  }
})
```

Closes #26